### PR TITLE
Add hl-line face.

### DIFF
--- a/smyx-theme.el
+++ b/smyx-theme.el
@@ -133,10 +133,10 @@
    `(header-line ((,class (:foreground ,smyx-yellow
                                        :background ,smyx-bg-1
                                        :box (:line-width -1 :style released-button)))))
-   `(highlight ((,class (:background ,smyx-gray-5))))
+   `(highlight ((,class (:background ,smyx-gray-8))))
 
    ;;; highlight current line
-   `(hl-line ((,class (:background ,smyx-green-2))))
+   `(hl-line ((,class (:background ,smyx-bg+2))))
    
    ;;; compilation
    `(compilation-column-face ((,class (:foreground ,smyx-blue))))


### PR DESCRIPTION
This pull request adds a face for highlighting the current line. I tried a bunch of colours orange, green, blue, etc.

It seems that the green produces the best results vs. abusing blueish colours, see for yourself below.
- It's easy enough to differentiate between selected text and the current line.
- When no text is selected, it's still easy enough to see clearly all characters.
- When the current line is close to the mode-line, there's also enough contrast.

![screen shot 2014-10-08 at 9 23 46 am](https://cloud.githubusercontent.com/assets/5206067/4559690/7958914c-4eee-11e4-8f8e-929434cce94c.png)

![screen shot 2014-10-08 at 9 24 13 am](https://cloud.githubusercontent.com/assets/5206067/4559692/7fdcab5c-4eee-11e4-8713-fa28af05d270.png)

![screen shot 2014-10-08 at 9 40 26 am](https://cloud.githubusercontent.com/assets/5206067/4559931/d2fc133e-4ef0-11e4-8ec2-13a23df66d7e.png)
