### PR TITLE
Fix #8, more contrast to comment face foreground.

### DIFF
--- a/smyx-theme.el
+++ b/smyx-theme.el
@@ -188,7 +188,7 @@
 
    ;;; font lock
    `(font-lock-builtin-face ((,class (:foreground ,smyx-orange))))
-   `(font-lock-comment-face ((,class (:foreground ,smyx-gray :italic t))))
+   `(font-lock-comment-face ((,class (:foreground ,smyx-gray-9 :italic t))))
    ;; `(font-lock-comment-delimiter-face ((,class (:foreground ,smyx-green)))) 
    `(font-lock-constant-face ((,class (:foreground ,smyx-red))))
    ;; `(font-lock-doc-face ((,class (:foreground ,smyx-green+0))))


### PR DESCRIPTION
This makes comments the same colour as line numbers.

![screen shot 2014-10-08 at 9 51 42 am](https://cloud.githubusercontent.com/assets/5206067/4560163/eebb7d60-4ef2-11e4-88e0-159204fdb3da.png)
