### PR TITLE
Fix #11, lighter region face.

### DIFF
--- a/smyx-theme.el
+++ b/smyx-theme.el
@@ -184,7 +184,7 @@
      ((,class (:foreground ,smyx-gray-7
                            :background ,smyx-gray-6
                            :box (:line-width -1 :color ,smyx-blue-5)))))
-   `(region ((,class (:background ,smyx-gray-9))))
+   `(region ((,class (:background ,smyx-black-3))))
    `(secondary-selection ((,class (:background ,smyx-bg+2))))
    `(trailing-whitespace ((,class (:background ,smyx-red))))
    `(vertical-border ((,class (:foreground ,smyx-gray-5 :background ,smyx-black))))


### PR DESCRIPTION
This makes the comments within a selection clearly visible. Per screenshots in the bug report, comments are not visible within selections.

The approach in many themes is similar, by using a colour a bit darker than the light highlight or lighter than the default background.

![screen shot 2014-10-13 at 3 22 43 pm](https://cloud.githubusercontent.com/assets/5206067/4618877/a39f5df4-530e-11e4-8ddd-465d1863351d.png)

On the `company-tooltip-selection` line, the full line is not selected and there's a small contrast between the region and the line highlight colour. It seems pretty common to do that for many themes.
