### PR TITLE
Use `:style nil` for Emacs 30

### DIFF
--- a/smyx-theme.el
+++ b/smyx-theme.el
@@ -558,9 +558,9 @@
                                    :box (:line-width 1 :style released-button)))))
    `(org-date ((,class (:foreground ,smyx-green))))
    `(org-done ((,class (:bold t :weight bold :foreground ,smyx-green-1
-                              :box (:line-width 1 :style none)))))
+                              :box (:line-width 1 :style nil)))))
    `(org-todo ((,class (:bold t :foreground ,smyx-yellow-org-todo :weight bold
-                              :box (:line-width 1 :style none)))))
+                              :box (:line-width 1 :style nil)))))
 
    `(org-level-1 ((,class (:foreground ,smyx-blue ))))
    `(org-level-2 ((,class (:foreground ,smyx-green ))))


### PR DESCRIPTION
This PR lets `smyx` work in Emacs 30. Relevant issue: https://github.com/doomemacs/themes/issues/809.

Smyck has been my favorite theme for like 7 years and thank you for porting it to Emacs.
